### PR TITLE
Add canonical URL to website metadata

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -57,6 +57,9 @@ export const WEBSITE_METADATA: Metadata = {
       'Full Stack Software Developer with 2+ years experience in Java, TypeScript, AWS, and more. Building scalable solutions from Portugal for global clients.',
     images: [`${baseUrl}eduardo_couto_og_image_optimized.jpg`],
   },
+  alternates: {
+    canonical: baseUrl,
+  },
 };
 
 export const JSON_LD = {


### PR DESCRIPTION
## Summary
Added canonical URL configuration to the website metadata to improve SEO and prevent duplicate content issues.

## Changes
- Added `alternates.canonical` property to `WEBSITE_METADATA` object pointing to the base URL
- This ensures search engines recognize the primary version of the site and consolidate ranking signals

## Implementation Details
The canonical URL is set to the `baseUrl` variable, which is the root domain of the website. This is a standard SEO best practice that helps search engines understand the preferred version of a page when multiple URLs might contain similar content.

https://claude.ai/code/session_01KsPXbqtXJUhGdJ4u2eKXzg